### PR TITLE
Add edit button

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/src/css/reflectDay.css
+++ b/src/css/reflectDay.css
@@ -278,3 +278,18 @@ body {
 .delete-item:hover {
     background-color: darkred;
 }
+
+.edit-item {
+    float: inline-end;
+    color: white;
+    padding: 10px;
+    margin-right: 10px;
+    background-color: #ddd;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.edit-item:hover {
+    background-color: darkgrey;
+}

--- a/src/javascript/reflect.js
+++ b/src/javascript/reflect.js
@@ -97,11 +97,28 @@ document.addEventListener('DOMContentLoaded', () => {
     dateCell.textContent = `Date: ${reflection.date}`; // Set the date text
     dateCell.classList.add('date-cell');
 
+    // Add delete button to reflection
     const deleteBtn = document.createElement('button');
     deleteBtn.innerText = 'delete';
     deleteBtn.classList.add('delete-item');
     deleteBtn.addEventListener('click', () => removeReflection(reflection.id));
     dateCell.appendChild(deleteBtn);
+
+    const editBtn = document.createElement('button');
+    editBtn.innerText = "edit";
+    editBtn.classList.add('edit-item');
+    editBtn.addEventListener('click', () => {
+      let reflections = document.querySelectorAll('textarea');
+      reflections[reflection.id-1].disabled = false;
+      console.log(reflection.id-1);
+      console.log(reflection);
+      reflections[reflection.id-1].addEventListener('input', () => {
+        reflection.text = reflections[reflection.id-1].value; // Update the reflection text
+        saveReflection(reflection); // Save the updated reflection
+      });
+    });
+
+    dateCell.appendChild(editBtn);
 
     // Append cells to the row
     reflectionRow.appendChild(indexCell);

--- a/src/javascript/reflect.js
+++ b/src/javascript/reflect.js
@@ -108,12 +108,11 @@ document.addEventListener('DOMContentLoaded', () => {
     editBtn.innerText = "edit";
     editBtn.classList.add('edit-item');
     editBtn.addEventListener('click', () => {
-      let reflections = document.querySelectorAll('textarea');
-      reflections[reflection.id-1].disabled = false;
-      console.log(reflection.id-1);
-      console.log(reflection);
-      reflections[reflection.id-1].addEventListener('input', () => {
-        reflection.text = reflections[reflection.id-1].value; // Update the reflection text
+      let reflections = document.querySelectorAll('textarea'); //get all textboxes
+      let selection = reflections[reflection.id-1]; //select desired one based on id of reflection target
+      selection.disabled = false; //enable textbox
+      selection.addEventListener('input', () => {
+        reflection.text = selection.value; // Update the reflection text
         saveReflection(reflection); // Save the updated reflection
       });
     });


### PR DESCRIPTION
I added an edit button that would appear for each reflection and allow the user to edit the textbox for the corresponding reflection, and the new value would be saved to LocalStorage.

Instructions for PR Team:
1. Open with Live Server and navigate to Reflect on the Day
2. Create a reflection
3. Verify that an 'edit' button appears next to the delete button for a reflection
4. Enter some text
5. Refresh the page
6. Use the edit button to enable a reflection's textbox
7. Edit reflection content, click off box, then refresh
8. Verify that new content has been saved

Notes: The edit button does not allow the user to replace the sentiment icon for a reflection. Unsure whether or not that is necessary

This branch can be deleted upon a successful merge.