### PR TITLE
CSS Adjustments to Project Tracker

### DIFF
--- a/__tests__/pipeline.test.js
+++ b/__tests__/pipeline.test.js
@@ -76,3 +76,14 @@ describe('Day Schedule Tests', () => {
         expect(rgbToHex("000000")).toBe(expectedReturn);
     });
 });
+
+/**
+ * Project Tracker Page
+ */
+describe('Basic user flow for Website', () => {
+    beforeAll(async () => {
+        await page.goto('https://cse110-sp24-group20.github.io/cse110-sp24-group20/src/html/projectTracker.html');
+    });
+
+
+})

--- a/__tests__/pipeline.test.js
+++ b/__tests__/pipeline.test.js
@@ -76,14 +76,3 @@ describe('Day Schedule Tests', () => {
         expect(rgbToHex("000000")).toBe(expectedReturn);
     });
 });
-
-/**
- * Project Tracker Page
- */
-describe('Basic user flow for Website', () => {
-    beforeAll(async () => {
-        await page.goto('https://cse110-sp24-group20.github.io/cse110-sp24-group20/src/html/projectTracker.html');
-    });
-
-
-})

--- a/src/css/projectTracker.css
+++ b/src/css/projectTracker.css
@@ -1,9 +1,10 @@
 /* project tracker */
 .project-tracker {
-    width: 80%;
+    width: 65%;
     max-width: 1200px;
     padding: 20px;
-    margin-left: 5%;
+    margin: 0 auto;
+    margin-top: 5%;
     background-color: rgba(255, 255, 255, 0.8);
     border-radius: 15px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
@@ -14,9 +15,9 @@
 }
 
 .project-count {
-    position: absolute;
-    top: 20px;
-    right: 20px;
+    position: relative;
+    margin-top: -10%;
+    margin-right: -68%;
     font-size: 18px;
     color: #333;
     background-color: rgba(255, 255, 255, 0.6); /* Semi-transparent background */
@@ -29,7 +30,7 @@
 .project-tracker h1 {
     text-align: center;
     color: #333;
-    margin-bottom: 20px;
+    margin-bottom: 40px;
     width: 100%;
 }
 
@@ -37,7 +38,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 100%;
+    width: 90%;
     margin-top: 20px;
 }
 
@@ -47,12 +48,13 @@
     display: flex;
     flex-direction: column-reverse; /* Ensures projects are added at the bottom */
     overflow-y: auto; /* Make the project list scrollable */
-    gap: 20px;
+    gap: 10px;
     background-color: rgba(255, 255, 255, 0.5);
     padding: 20px;
     border-radius: 10px;
-    max-height: 500px; /* Set a max height to the projects container */
-    box-sizing: border-box;
+    max-height: 400px; /* Set a max height to the projects container */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    align-items: center;
 }
 
 .project {
@@ -76,9 +78,11 @@
 
 .project-input-container {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 20px;
-    width: 100%;
+    /**gap: 20px;*/
+    width: 80%;
+    margin-top: 20px;
 }
 
 input[type="range"] {
@@ -278,7 +282,11 @@ body {
     display: flex;
     margin-right: 2%;
     flex-direction: row-reverse;
-    width: 100%;
+    width: 90%;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+    position: relative;
 }
 
 /* modal styling */

--- a/src/html/projectTracker.html
+++ b/src/html/projectTracker.html
@@ -48,9 +48,6 @@
                     <label for="eventName">Project Name:</label>&nbsp;
                     <input type="text" id="eventName" name="eventName" placeholder="Name of your Project" required></textarea><br>
 
-                    <label for="dateTime">Deadline:</label>&nbsp;
-                    <input type="datetime-local" id="dateTime" name="dateTime" placeholder="Deadline of your Project" required><br>
-
                     <button class="submit">Submit</button>
                 </form>
             </div>

--- a/src/javascript/project_tracker.js
+++ b/src/javascript/project_tracker.js
@@ -35,6 +35,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     function createProjectElement(name) {
+        if (typeof name != 'string' || name === null){
+            console.error('Project name is undefined or null. Cannot create project');
+            return;
+        }
         const newProject = document.createElement('div'); // Create a new div element for the project
         newProject.className = 'project'; // Add the 'project' class to the div
         newProject.dataset.name = name; // Store the project name in a data attribute for later reference

--- a/src/javascript/project_tracker.js
+++ b/src/javascript/project_tracker.js
@@ -146,7 +146,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 updateProgressBar(projectElement);
             }
         });
-        updateProjectCount(projects.length); // Update the project count with the number of loaded projects
     }
     
     /**


### PR DESCRIPTION
CSS changes:
- project counter is no longer cut out
- the whole project tracker container is padded around so its more centered
- the projects no are full width so they take up the whole space
- just made it cuter tbh

Also has royce's changes:
- now when reloading the task number should not change
- removed user input for date on the project tracker page since not used anymore

You can delete the branch once merged into main